### PR TITLE
Fix #15

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -354,6 +354,7 @@ db_ack <- function(db, queue, id, lock, success) {
     name = queue
   )$lockdir
 
+  try_silent(dbDisconnect(lock))
   lock <- message_lock_file(lockdir, queue, id)
   unlink(lock)
 


### PR DESCRIPTION
Disconnects from the message's lock in db_ack(). Removes the annoying warning about dangling connections.