### PR TITLE
fix #25: publish several messages in one transaction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ LazyData: true
 URL: https://github.com/r-lib/liteq#readme
 BugReports: https://github.com/r-lib/liteq/issues
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Imports:
     assertthat,
     DBI,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 
+# 1.x.x
+
+* `publish()` now accepts multiple messages (note that `title` and `message`
+  must be of the same length) and publishes them in a single transaction (#25).
+
 # 1.1.0
 
 * Work around a SQLITE bug that resets the database busy timeout after a

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 
 # 1.x.x
 
-* `publish()` now accepts multiple messages (note that `title` and `message`
-  must be of the same length) and publishes them in a single transaction (#25).
+* `publish()` now accepts multiple messages (note that `title` and
+  `message` must be of the same length) and publishes them in a single
+  transaction (#25, @Enchufa2).
 
 # 1.1.0
 

--- a/R/db.R
+++ b/R/db.R
@@ -169,14 +169,20 @@ db_list_queues <- function(db) {
 }
 
 db_publish <- function(db, queue, title, message) {
-  do_db_execute(
-    db,
-    "INSERT INTO ?tablename (title, message)
-     VALUES (?title, ?message)",
-    tablename = db_queue_name(queue),
-    title = title,
-    message = message
-  )
+  con <- db_connect(db)
+  on.exit(dbDisconnect(con))
+  dbWithTransaction(con, {
+    for (i in seq_along(title)) {
+      db_execute(
+        con,
+        "INSERT INTO ?tablename (title, message)
+         VALUES (?title, ?message)",
+        tablename = db_queue_name(queue),
+        title = title[i],
+        message = message[i]
+      )
+    }
+  })
   invisible()
 }
 

--- a/R/messages.R
+++ b/R/messages.R
@@ -41,11 +41,12 @@ message_lock_file <- function(lockdir, queue, id) {
   file.path(lockdir, paste0(queue, "-", id, ".lock"))
 }
 
-#' Publish a message in a queue
+#' Publish messages in a queue
 #'
 #' @param queue The queue object.
-#' @param title The title of the message. It can be the empty string.
-#' @param message The body of the message. It can be the empty string.
+#' @param title The title of the messages. It can be the empty string.
+#' @param message The body of the messages. It can be the empty string.
+#'   Must be the same length as `title`.
 #'
 #' @family liteq messages
 #' @seealso [liteq] for examples
@@ -53,8 +54,9 @@ message_lock_file <- function(lockdir, queue, id) {
 
 publish <- function(queue, title = "", message = "") {
   assert_that(is_queue(queue))
-  assert_that(is_string(title))
-  assert_that(is_string(message))
+  assert_that(is.character(title))
+  assert_that(is.character(message))
+  assert_that(length(title) == length(message))
   db_publish(queue$db, queue$name, title, message)
 }
 

--- a/man/ack.Rd
+++ b/man/ack.Rd
@@ -15,13 +15,15 @@ Acknowledge that the work on a message has finished successfully
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{consume}},
-  \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/consume.Rd
+++ b/man/consume.Rd
@@ -21,13 +21,15 @@ Blocks and waits for a message if there isn't one to work on currently.
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/create_queue.Rd
+++ b/man/create_queue.Rd
@@ -25,7 +25,9 @@ It also creates the database, if it does not exist.
 \seealso{
 \link{liteq} for examples
 
-Other liteq queues: \code{\link{delete_queue}},
-  \code{\link{ensure_queue}}, \code{\link{list_queues}}
+Other liteq queues: 
+\code{\link{delete_queue}()},
+\code{\link{ensure_queue}()},
+\code{\link{list_queues}()}
 }
 \concept{liteq queues}

--- a/man/delete_queue.Rd
+++ b/man/delete_queue.Rd
@@ -17,7 +17,9 @@ Delete a queue
 \seealso{
 \link{liteq} for examples
 
-Other liteq queues: \code{\link{create_queue}},
-  \code{\link{ensure_queue}}, \code{\link{list_queues}}
+Other liteq queues: 
+\code{\link{create_queue}()},
+\code{\link{ensure_queue}()},
+\code{\link{list_queues}()}
 }
 \concept{liteq queues}

--- a/man/ensure_queue.Rd
+++ b/man/ensure_queue.Rd
@@ -28,7 +28,9 @@ If it does not exist, then the queue will be created.
 \seealso{
 \link{liteq} for examples
 
-Other liteq queues: \code{\link{create_queue}},
-  \code{\link{delete_queue}}, \code{\link{list_queues}}
+Other liteq queues: 
+\code{\link{create_queue}()},
+\code{\link{delete_queue}()},
+\code{\link{list_queues}()}
 }
 \concept{liteq queues}

--- a/man/is_empty.Rd
+++ b/man/is_empty.Rd
@@ -18,13 +18,15 @@ Check if a queue is empty
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/list_failed_messages.Rd
+++ b/man/list_failed_messages.Rd
@@ -18,12 +18,15 @@ List failed messages in a queue
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}}, \code{\link{is_empty}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/list_messages.Rd
+++ b/man/list_messages.Rd
@@ -18,12 +18,15 @@ List all messages in a queue
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}}, \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{message_count}}, \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/list_queues.Rd
+++ b/man/list_queues.Rd
@@ -18,7 +18,9 @@ List all queues in a database
 \seealso{
 \link{liteq} for examples
 
-Other liteq queues: \code{\link{create_queue}},
-  \code{\link{delete_queue}}, \code{\link{ensure_queue}}
+Other liteq queues: 
+\code{\link{create_queue}()},
+\code{\link{delete_queue}()},
+\code{\link{ensure_queue}()}
 }
 \concept{liteq queues}

--- a/man/liteq.Rd
+++ b/man/liteq.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{liteq}
 \alias{liteq}
-\alias{liteq-package}
 \title{Lightweight Portable Message Queue Using 'SQLite'}
 \description{
 Message queues for R. Built on top of 'SQLite' databases.
@@ -17,7 +16,7 @@ locked by 'SQLite', the process that tries to access it, must wait until
 it is unlocked. The maximum amount of waiting time is by default 10
 seconds, and it can be changed via the \code{R_LITEQ_BUSY_TIMEOUT}
 environment variable, in milliseconds. If you have many concurrent
-processes using the same liteq database, and see \code{database locked}
+processes using the same liteq database, and see \verb{database locked}
 errors, then you can try to increase the timeout value.
 }
 

--- a/man/message_count.Rd
+++ b/man/message_count.Rd
@@ -18,12 +18,15 @@ Get the number of messages in a queue.
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}}, \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/publish.Rd
+++ b/man/publish.Rd
@@ -2,29 +2,33 @@
 % Please edit documentation in R/messages.R
 \name{publish}
 \alias{publish}
-\title{Publish a message in a queue}
+\title{Publish messages in a queue}
 \usage{
 publish(queue, title = "", message = "")
 }
 \arguments{
 \item{queue}{The queue object.}
 
-\item{title}{The title of the message. It can be the empty string.}
+\item{title}{The title of the messages. It can be the empty string.}
 
-\item{message}{The body of the message. It can be the empty string.}
+\item{message}{The body of the messages. It can be the empty string.
+Must be the same length as \code{title}.}
 }
 \description{
-Publish a message in a queue
+Publish messages in a queue
 }
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}}, \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/remove_failed_messages.Rd
+++ b/man/remove_failed_messages.Rd
@@ -18,12 +18,15 @@ Remove failed messages from the queue
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}}, \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{publish}},
-  \code{\link{requeue_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{requeue_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/requeue_failed_messages.Rd
+++ b/man/requeue_failed_messages.Rd
@@ -18,12 +18,15 @@ Requeue failed messages
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}}, \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{try_consume}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{try_consume}()}
 }
 \concept{liteq messages}

--- a/man/try_consume.Rd
+++ b/man/try_consume.Rd
@@ -18,12 +18,15 @@ Consume a message if there is one available
 \seealso{
 \link{liteq} for examples
 
-Other liteq messages: \code{\link{ack}},
-  \code{\link{consume}}, \code{\link{is_empty}},
-  \code{\link{list_failed_messages}},
-  \code{\link{list_messages}}, \code{\link{message_count}},
-  \code{\link{publish}},
-  \code{\link{remove_failed_messages}},
-  \code{\link{requeue_failed_messages}}
+Other liteq messages: 
+\code{\link{ack}()},
+\code{\link{consume}()},
+\code{\link{is_empty}()},
+\code{\link{list_failed_messages}()},
+\code{\link{list_messages}()},
+\code{\link{message_count}()},
+\code{\link{publish}()},
+\code{\link{remove_failed_messages}()},
+\code{\link{requeue_failed_messages}()}
 }
 \concept{liteq messages}

--- a/tests/testthat/test-messages.R
+++ b/tests/testthat/test-messages.R
@@ -8,9 +8,11 @@ test_that("publish, is_empty, and message_count", {
   expect_true(is_empty(q))
   expect_equal(message_count(q), 0)
 
-  for (i in 1:10) {
+  for (i in 1:5) {
     publish(q, title = title <- as.character(i), message = text <- "MSG")
   }
+  expect_error(publish(q, title = title <- as.character(6:10), message = text))
+  publish(q, title = title, message = rep(text, length(title)))
   expect_false(is_empty(q))
   expect_equal(message_count(q), 10)
 })

--- a/tests/testthat/test-messages.R
+++ b/tests/testthat/test-messages.R
@@ -11,8 +11,12 @@ test_that("publish, is_empty, and message_count", {
   for (i in 1:5) {
     publish(q, title = title <- as.character(i), message = text <- "MSG")
   }
-  expect_error(publish(q, title = title <- as.character(6:10), message = text))
-  publish(q, title = title, message = rep(text, length(title)))
+
+  # title and message lengths must match
+  expect_error(publish(q, title = "one", message = c("one", "two")))
+
+  # multiple messages at once
+  publish(q, title = as.character(6:10), message = rep("MSG", 5))
   expect_false(is_empty(q))
   expect_equal(message_count(q), 10)
 })


### PR DESCRIPTION
Example:

```r
library(liteq)

task <- function(db) {
  library(liteq)
  q <- ensure_queue("jobs", db = db)
  msg <- consume(q)
  out <- msg$title
  Sys.sleep(10)
  ack(msg)
  out
}

db <- tempfile()
q <- ensure_queue("jobs", db = db)

n <- 10
workers <- replicate(n, callr::r_bg(task, list(db=db)))

publish(q, letters[1:n], rep("something", n))

Sys.sleep(15)
sort(sapply(workers, function(x) x$get_result()))
#>  [1] "a" "b" "c" "d" "e" "f" "g" "h" "i" "j"
```