### PR TITLE
close #28: fix concurrency issues and deadlocks

### DIFF
--- a/R/messages.R
+++ b/R/messages.R
@@ -23,7 +23,7 @@ make_message <- function(id, title, message, db, queue, lockdir) {
   lock <- message_lock_file(lockdir, queue, id)
   con <- db_connect(lock)
   db_execute(con, "CREATE TABLE foo (id INT)")
-  db_execute(con, "BEGIN EXCLUSIVE")
+  db_execute(con, "BEGIN IMMEDIATE")
 
   structure(
     list(


### PR DESCRIPTION
This is my take at #28, which partially revisits #26. This PR basically 

- makes `do_db_execute` take the lock, because every call to it is a write;
- makes `publish` take the lock, same reason;
- substitutes `EXCLUSIVE` locks with `IMMEDIATE` locks.

This works very well for my use case in #28, but please take a look to ensure that I'm not missing something. Compared to master, tests are much quicker now, but two tests fail, which I believe are spurious errors due to the fact that IMMEDIATE locks can coexist with readers:

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test-db.R:79:3): db_lock ───────────────────────────────────────────
`db_query(con3, "SELECT * FROM meta")` did not throw an error.
── Failure (test-db.R:82:3): db_lock ───────────────────────────────────────────
`db_query(con2, "SELECT * FROM meta")` did not throw an error.

[ FAIL 2 | WARN 0 | SKIP 11 | PASS 173 ]

```